### PR TITLE
Fix comment length check

### DIFF
--- a/Model/ResourceModel/Grid/Collection.php
+++ b/Model/ResourceModel/Grid/Collection.php
@@ -43,8 +43,8 @@ class Collection extends SearchResult
         $items = parent::getItems();
 
         foreach ($items as $item) {
-            if (strlen($item->getComment()) > 75) {
-                $item->setComment(substr($item->getComment(), 0, 75) . '...');
+            if ($item->getComment() !== null && strlen((string) $item->getComment()) > 75) {
+                $item->setComment(substr((string) $item->getComment(), 0, 75) . '...');
             }
         }
 


### PR DESCRIPTION
## Summary
- avoid calling strlen() if comment is null in Grid collection

## Testing
- `php -l Model/ResourceModel/Grid/Collection.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855256381c8833292e170954018c9bb